### PR TITLE
Added example of VCL-file to improve integration with Spree

### DIFF
--- a/public/fastly_default.vcl
+++ b/public/fastly_default.vcl
@@ -1,0 +1,82 @@
+sub vcl_recv {
+    if (req.request != "HEAD" && req.request != "GET" && req.request != "FASTLYPURGE") {
+      return(pass);
+    }
+
+    if (req.url ~ "csrf_meta_tags") {
+      set req.hash_always_miss = true; 
+    }
+
+    if (req.http.Cookie ~ "_session=" || req.http.Cookie ~ "guest_token=") {
+      # The request have an authorization cookie so force a miss
+      set req.hash_always_miss = true; 
+    }
+    
+    return(lookup);
+}
+
+sub vcl_fetch {
+
+#FASTLY fetch
+
+  if ((beresp.status == 500 || beresp.status == 503) && req.restarts < 1 && (req.request == "GET" || req.request == "HEAD")) {
+    restart;
+  }
+
+  if(req.restarts > 0 ) {
+    set beresp.http.Fastly-Restarts = req.restarts;
+  }
+
+  if (beresp.http.Set-Cookie) {
+    set req.http.Fastly-Cachetype = "SETCOOKIE";
+    return (pass);
+  }
+
+  if (beresp.http.Cache-Control ~ "private") {
+    set req.http.Fastly-Cachetype = "PRIVATE";
+    return (pass);
+  }
+
+  if (beresp.status == 500 || beresp.status == 503) {
+    set req.http.Fastly-Cachetype = "ERROR";
+    set beresp.ttl = 1s;
+    set beresp.grace = 5s;
+    return (deliver);
+  }
+
+  if (beresp.http.Expires || beresp.http.Surrogate-Control ~ "max-age" || beresp.http.Cache-Control ~"(s-maxage|max-age)") {
+    # keep the ttl here
+  } else {
+    # apply the default ttl
+    set beresp.ttl = 3600s;
+  }
+
+  return(deliver);
+}
+
+sub vcl_hit {
+#FASTLY hit
+
+  if (!obj.cacheable) {
+    return(pass);
+  }
+  return(deliver);
+}
+
+sub vcl_miss {
+#FASTLY miss
+  return(fetch);
+}
+
+sub vcl_deliver {
+#FASTLY deliver
+  return(deliver);
+}
+
+sub vcl_error {
+#FASTLY error
+}
+
+sub vcl_pass {
+#FASTLY pass
+}


### PR DESCRIPTION
Support of csrf_meta_tags and requests with Cookie, but without Set-Cookie header in the response.